### PR TITLE
Fetch data on change of URL after the Vue instance created.

### DIFF
--- a/src/components/VueGist.vue
+++ b/src/components/VueGist.vue
@@ -29,6 +29,16 @@ export default {
       gistUrl: "https://gist.github.com/"
     };
   },
+  watch: {
+    gistId: {
+      handler: function (newVal, oldVal) {
+        console.log("Prop changed : ", newVal, " | was: ", oldVal);
+        this.$data.gistData = "loading...";
+        this.getGistData();
+      },
+      deep: true,
+    },
+  },
   computed: {
     url() {
       return `${this.gistUrl}${this.gistId}.json`

--- a/src/components/VueGist.vue
+++ b/src/components/VueGist.vue
@@ -31,8 +31,7 @@ export default {
   },
   watch: {
     gistId: {
-      handler: function (newVal, oldVal) {
-        console.log("Prop changed : ", newVal, " | was: ", oldVal);
+      handler: function () {
         this.$data.gistData = "loading...";
         this.getGistData();
       },


### PR DESCRIPTION
### What is in this PR:

This PR has the enhancement of the gist data load when the gistID changes after the Vue instance are created.

- Change the gist id dynamically after the Vue instance created.

### How to test this PR:
Steps:
1. Write code to change the gist id after the Vue instance created.
2. Now the observe it should show the second gist id's data.

### Related PR:

New-PR

### Screenshot and preview:

[https://drive.google.com/file/d/1czXYLzJTbgBJrN53Z6yINLJhDErMzmiZ/view?usp=sharing](url)