### PR TITLE
Update token for danger CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,4 +39,4 @@ jobs:
     - name: Run Danger
       run: npx danger ci
       env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.DANGER_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -39,4 +39,4 @@ jobs:
     - name: Run Danger
       run: npx danger ci
       env: 
-        GITHUB_TOKEN: ${{ secrets.DANGER_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_TOKEN }}


### PR DESCRIPTION
### What is in this PR:

As per https://github.com/danger/danger-js/issues/1031 `GITHUB_TOKEN` available to github actions is not able to comment on PR. So add new Token for PR.